### PR TITLE
キャッシュファイルの削除まわりの修正

### DIFF
--- a/sayaka.php
+++ b/sayaka.php
@@ -980,10 +980,10 @@ function invalidate_cache()
 	global $cachedir;
 
 	// アイコンは7日分くらいか
-	system("find {$cachedir} -atime +7 -exec rm {} +");
+	system("find {$cachedir} -name icon-\* -type f -atime +7 -exec rm {} +");
 
 	// 写真は24時間分くらいか
-	system("find {$cachedir} -atime +1 -exec rm {} +");
+	system("find {$cachedir} -name http\* -type f -atime +1 -exec rm {} +");
 }
 
 // UTF-8 文字列を分割する。


### PR DESCRIPTION
以下の二点の修正です。
* 画像とアイコンを区別していなかったのを修正
* cacheディレクトリ自体が削除対象にならないように -type f を付加

-name ～があればキャッシュディレクトリ自体は対象になりませんが、念のため-type fを追加しています。