### PR TITLE
フォントの高さの自動取得

### DIFF
--- a/cellsize.c
+++ b/cellsize.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+
+int main(int argc, char *argv[])
+{
+	int height, width;
+	struct winsize ws;
+
+	height = width = -1;
+
+	if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != -1) {
+		if (ws.ws_row != 0) {
+			height = ws.ws_ypixel / ws.ws_row;
+		}
+
+		if (ws.ws_col != 0) {
+			width = ws.ws_xpixel / ws.ws_col;
+		}
+	}
+
+	switch (argc) {
+	case 1:
+		printf("%d, %d\n", height, width);
+		break;
+	case 2:
+		if (*argv[1]++ == '-') {
+			switch (*argv[1]) {
+			case 'h':
+				printf("%d\n", height);
+				break;
+			case 'w':
+				printf("%d\n", width);
+				break;
+			case 'v':
+				printf("Terminal Size: %dx%d (%dx%d)\nCell Height: %d\nCell Width: %d\n",
+				       ws.ws_col, ws.ws_row,
+				       ws.ws_xpixel, ws.ws_ypixel,
+				       height, width);
+			default:
+				return 1;
+			}
+		}
+		break;
+	default:
+		return 1;
+	}
+
+	return 0;
+}

--- a/sayaka.php
+++ b/sayaka.php
@@ -30,7 +30,7 @@
 	$version = "3.0.9 (2015/06/14)";
 	$progname = $_SERVER["argv"][0];
 
-	$fontheight = 14;
+	$fontheight = 0;
 	$color_mode = 256;
 
 	// まず引数のチェックをする
@@ -123,10 +123,6 @@
 		}
 	}
 
-	// フォント高さからアイコンの大きさを決定
-	$iconsize = intval($fontheight * 2.5);
-	$imagesize = intval($fontheight * 8.5);
-
 	// ここからメインルーチン
 	require_once "TwistOAuth.php";
 	require_once "subr.php";
@@ -190,6 +186,8 @@ function init_stream()
 	global $img2sixel;
 	global $cachedir;
 	global $tput;
+	global $cellsize;
+	global $fontheight;
 
 	// 色の初期化
 	init_color();
@@ -213,6 +211,15 @@ function init_stream()
 
 	// tput
 	$tput = rtrim(`which tput`);
+
+	// cellsize
+	// --font が未指定の時のみ cellsize を使う
+	if ($fontheight == 0 && file_exists("./cellsize")) {
+		$cellsize = "./cellsize";
+	}
+	else {
+		$cellsize = "";
+	}
 
 	// pcntl モジュールがあればシグナルハンドラを設定。
 	// なければウィンドウサイズの変更が受け取れないだけなので
@@ -1226,6 +1233,10 @@ function signal_handler($signo)
 {
 	global $screen_cols;
 	global $tput;
+	global $cellsize;
+	global $fontheight;
+	global $iconsize;
+	global $imagesize;
 	global $debug;
 
 	switch ($signo) {
@@ -1235,8 +1246,28 @@ function signal_handler($signo)
 			$screen_cols = rtrim(`{$tput} cols`);
 		}
 		$screen_cols += 0;
+
+		// ターミナルのフォントの高さを取得
+		if ($cellsize != "") {
+			$fontheight = rtrim(`{$cellsize} -h`);
+			$fontheight += 0;
+		}
+
+		// cellsize が無かった時や、値がとれなかった時は
+		// デフォルト値として 14 を使う。
+		if ($fontheight <= 0) {
+			$fontheight = 14;
+		}
+
+		// フォント高さからアイコンの大きさを決定
+		$iconsize = intval($fontheight * 2.5);
+		$imagesize = intval($fontheight * 8.5);
+
 		if ($debug) {
 			print "screen columns={$screen_cols}\n";
+			print "font height=${fontheight}\n";
+			print "iconsize={$iconsize}\n";
+			print "imagesize={$imagesize}\n";
 		}
 		break;
 	 default:


### PR DESCRIPTION
フォントの高さの自動取得対応です。
実際にフォントの高さを取得する部分は別プログラム(cellsize)とし、
sayaka.php からはそのプログラムの出力を使うようにしています。

cellsize.c は cellsize のサンプル実装です。
文字セルサイズの取得方法として、日本の端末エミュレータ屋さんの間で最も有望視されている
TIOCGWINSZ で取得した winsize 構造体のメンバから計算する方法を使っています。
以下のOSで cc (or gcc) -o cellsize cellsize.c でコンパイルできる事を確認しています。
- FreeBSD 10.1
- NetBSD 6.1.5
- OpenBSD 5.7
- Red Hat Enterprize Linux 6.6
- Solaris 9