### PR TITLE
sixel画像終了時のカーソル位置の違いへの対応

### DIFF
--- a/sayaka.php
+++ b/sayaka.php
@@ -455,9 +455,15 @@ function showstatus($status)
 	// 今のところローカルアカウントはない
 	$profile_image_url = $s->user->profile_image_url;
 
+	// 改行x3 + カーソル上移動x3 を行ってあらかじめスクロールを発生させ
+	// アイコン表示時にスクロールしないようにしてからカーソル位置を保存する
+	// (スクロールするとカーソル位置復元時に位置が合わない)
+	print "\n\n\n".CSI."3A".ESC."7";
 	show_icon(unescape($s->user->screen_name), $profile_image_url);
 	print "\r";
-	print CSI."3A";
+	// カーソル位置保存/復元に対応していない端末でも動作するように
+	// カーソル位置復元前にカーソル上移動x3を行う
+	print CSI."3A".ESC."8";
 
 	print_("{$name} {$userid}{$verified}{$protected}");
 	print "\n";


### PR DESCRIPTION
DEC純正の端末とxterm等の近年のsixel対応端末エミュレータではsixel画像表示後のカーソル位置が違うので、それへの対応です。

#### xterm等の挙動
画像の終了位置が含まれる行の次の行にカーソルが移動。
例えば行の高さが14ドットで画像の高さがそれの2.5倍の35ドットだった場合、
 1. 6ドット単位に切り上げて36ドットとする
 2. 36ドットは3行目(29～42ドット)になるので、その次の4行目にカーソルが移動する。

#### VT382の挙動 (多分VT330も)
画像の次の行位置(ドット単位)が含まれる行に移動。
VT382の行の高さは30ドットなので、画像の高さが2.5倍の75ドットだった場合、
 1. 6ドット単位に切り上げて78ドットとする
 2. 次の行位置(79ドット)が含まれる3行目(61～90ドット)にカーソルが移動する。

#### 対応方法のコンセプト
 1. DECSC でカーソル位置保存
 2. 画像を表示
 3. DECRC でカーソル位置を復元

ただし画像表示中にスクロールした場合に正しく動かないため、画像(アイコン)表示前に3行の改行を表示させてあらかじめスクロールさせておく。
またDECSC/DECRC非対応端末での挙動を変えない為にDECRCの前のCUU 3を残す。