### PR TITLE
フォントの横幅の取得とアイコンサイズの調整

### DIFF
--- a/sayaka.php
+++ b/sayaka.php
@@ -1254,6 +1254,7 @@ function signal_handler($signo)
 	global $tput;
 	global $cellsize;
 	global $fontheight;
+	global $fontwidth;
 	global $iconsize;
 	global $imagesize;
 	global $debug;
@@ -1266,10 +1267,15 @@ function signal_handler($signo)
 		}
 		$screen_cols += 0;
 
+		$fontwidth = 0;
 		// ターミナルのフォントの高さを取得
 		if ($cellsize != "") {
 			$fontheight = rtrim(`{$cellsize} -h`);
 			$fontheight += 0;
+
+			// 幅も取ってみる
+			$fontwidth = rtrim(`{$cellsize} -v`);
+			$fontwidth += 0;
 		}
 
 		// cellsize が無かった時や、値がとれなかった時は
@@ -1282,9 +1288,16 @@ function signal_handler($signo)
 		$iconsize = intval($fontheight * 2.5);
 		$imagesize = intval($fontheight * 8.5);
 
+		// フォントの幅が取れた場合はアイコンサイズがインデント量より
+		// 大きくならないように調整する
+		if ($fontwidth > 0 && $iconsize > $fontwidth * 6 - 2) {
+			$iconsize = $fontwidth * 6 - 2;
+		}
+
 		if ($debug) {
 			print "screen columns={$screen_cols}\n";
 			print "font height=${fontheight}\n";
+			print "font width=${fontwidth}\n";
 			print "iconsize={$iconsize}\n";
 			print "imagesize={$imagesize}\n";
 		}


### PR DESCRIPTION
VT382では文字セルのサイズが30x12です。
アイコンサイズは30x2.5=75となりますが、インデント量は12x6=72となりアイコンと文字が(わずかに)重なってしまいます。

このパッチは、cellsizeで高さが取れた時は幅も取得し、インデント量に比べてアイコンサイズが大きい場合はアイコンサイズを小さくする為のものです。
調整後のアイコンサイズは暫定でインデント量-2としていますが、問題があるようならば変えて下さい。