### PR TITLE
vala-make2 への依存関係を追加して、make のみでビルド出来るようにする。

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ lang/vala, devel/glib2, graphics/gdk-pixbuf2, net/glib-networking
 コンパイルは以下のようにします。
 
 ```
-% make vala-make2
+% cd vala
 % make
 ```
 

--- a/vala/Makefile
+++ b/vala/Makefile
@@ -99,35 +99,35 @@ VALAMAKE_COMMON_OPTS= \
 		-l "${CC} " \
 		-L "${LIBS} " \
 
-sayaka:
+sayaka:	vala-make2
 	@${VALAMAKE} ${VALAMAKE_COMMON_OPTS} \
 		-o sayaka \
 		${SRCS_sayaka}
 
 .PHONY:	clean-sayaka
-clean-sayaka:
+clean-sayaka:	vala-make2
 	@${VALAMAKE} --clean ${VALAMAKE_COMMON_OPTS} \
 		-o sayaka \
 		${SRCS_sayaka}
 
-sixelv:
+sixelv:	vala-make2
 	@${VALAMAKE} ${VALAMAKE_COMMON_OPTS} \
 		-o sixelv \
 		${SRCS_sixelv}
 
 .PHONY:	clean-sixelv
-clean-sixelv:
+clean-sixelv:	vala-make2
 	@${VALAMAKE} --clean ${VALAMAKE_COMMON_OPTS} \
 		-o sixelv \
 		${SRCS_sixelv}
 
-h:
+h:	vala-make2
 	@${VALAMAKE} ${VALAMAKE_COMMON_OPTS} \
 		-o h \
 		${SRCS_h}
 
 .PHONY:	clean-h
-clean-h:
+clean-h:	vala-make2
 	@${VALAMAKE} --clean ${VALAMAKE_COMMON_OPTS} \
 		-o h  \
 		${SRCS_h}


### PR DESCRIPTION
make のみでビルド出来る方が便利だと思うのですが、どうでしょうか
その方がportsのMakefileがすっきりするので……
