### PR TITLE
DEBUG が define されていない時のビルドエラー修正

### DIFF
--- a/vala/mtls.native.c
+++ b/vala/mtls.native.c
@@ -30,8 +30,9 @@
 
 //#define DEBUG
 
-#if defined(DEBUG)
 #include <sys/time.h>
+
+#if defined(DEBUG)
 #define TRACE(fmt...)	do { \
 	struct timeval tv;	\
 	TRACE_tv(&tv, fmt);	\


### PR DESCRIPTION
DEBUG が define されていない時にビルドエラーになる事への修正です。
