### PR TITLE
Fix native_term_support_sixel to parse "\x1b[?63;4c" correctly.

### DIFF
--- a/vala/System.OS.native.c
+++ b/vala/System.OS.native.c
@@ -102,7 +102,14 @@ native_term_support_sixel()
 		e = strchr(p, ';');
 		if (e) {
 			*e++ = '\0';
+		} else {
+			e = strrchr(p, 'c');
+			if (e) {
+				*e = '\0';
+				e = NULL;
+			}
 		}
+
 		if (strcmp(p, "4") == 0) {
 			return 1;
 		}


### PR DESCRIPTION
native_term_support_sixel() returns 0 if '4' is the last parameter of the response of Primary DA.
As far as I know, no terminals responses such sequence for now, but please fix it just in case.