### PR TITLE
Add a dumb CI script for NetBSD and ubuntu.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [ ci-netbsd ]
+  pull_request:
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Check container sha tags
+        run: |
+          docker pull "ubuntu:jammy"
+          docker inspect "ubuntu:jammy" --format=${{ '{{.RepoDigests}}{{.Created}}' }}
+
+
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    container:
+      image: ubuntu:jammy
+
+    steps:
+      - name: Install distro packages
+        env:
+         UBUNTU_PACKAGES_MAKE: >
+            build-essential
+            pkg-config
+            bmake
+            libbsd-dev
+            libwslay-dev
+            libwebp-dev
+            libmbedtls-dev
+
+        run: |
+          cat /etc/lsb-release
+          echo "apt-get update -qq -y"
+          apt-get update -qq -y
+          echo "apt-get install -q -y git"
+          apt-get install -q -y git
+          PACKAGES=$(echo "$PACKAGES $UBUNTU_PACKAGES_MAKE" | tr -d '\n')
+          echo "apt-get install -y $PACKAGES"
+          apt-get install -y $PACKAGES
+
+      - uses: actions/checkout@v4
+        with:
+          #repository: isaki68k/sayaka
+          fetch-depth: 200
+
+      - name: Fetch git tags
+        run: |
+          pwd
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git branch
+          git fetch --prune --unshallow --tags
+          echo $PATH
+
+      - name: Run make
+        run: |
+          sh configure
+          bmake -DRELEASE sayaka
+
+  build-netbsd:
+    name: "build (NetBSD/amd64 9.3 with pkgsrc)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install packages and run configure and make (on the NetBSD VM)
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          # Check https://github.com/NetBSD/pkgsrc/blob/trunk/net/sayaka/Makefile to check dependencies
+          prepare: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
+            pkg_add pkgconf git-base
+            pkg_add gcc10
+            pkg_add libwebp mbedtls wslay
+
+          run: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
+            export PATH=/usr/pkg/gcc10/bin:${PATH}
+            CC=/usr/pkg/gcc10/bin/gcc CXX=/usr/pkg/gcc10/bin/g++ sh configure
+            make -DRELEASE sayaka

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,72 +2,35 @@ name: CI
 
 on:
   push:
-    branches: [ ci-netbsd ]
   pull_request:
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
+  build-linux:
     strategy:
       fail-fast: false
-    steps:
-      - name: Check container sha tags
-        run: |
-          docker pull "ubuntu:jammy"
-          docker inspect "ubuntu:jammy" --format=${{ '{{.RepoDigests}}{{.Created}}' }}
-
-
-  build:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-
-    container:
-      image: ubuntu:jammy
+      matrix:
+        os: [ubuntu-22.04, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install distro packages
-        env:
-         UBUNTU_PACKAGES_MAKE: >
-            build-essential
-            pkg-config
-            bmake
-            libbsd-dev
-            libwslay-dev
-            libwebp-dev
-            libmbedtls-dev
-
+      - name: install packages
         run: |
-          cat /etc/lsb-release
-          echo "apt-get update -qq -y"
-          apt-get update -qq -y
-          echo "apt-get install -q -y git"
-          apt-get install -q -y git
-          PACKAGES=$(echo "$PACKAGES $UBUNTU_PACKAGES_MAKE" | tr -d '\n')
-          echo "apt-get install -y $PACKAGES"
-          apt-get install -y $PACKAGES
+          sudo apt update
+          sudo apt upgrade -y
+          sudo apt install -y build-essential pkg-config bmake libbsd-dev libwslay-dev libwebp-dev libmbedtls-dev
 
       - uses: actions/checkout@v4
         with:
           #repository: isaki68k/sayaka
           fetch-depth: 200
 
-      - name: Fetch git tags
-        run: |
-          pwd
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          git branch
-          git fetch --prune --unshallow --tags
-          echo $PATH
-
-      - name: Run make
+      - name: configure and make
         run: |
           sh configure
           bmake -DRELEASE sayaka
 
   build-netbsd:
-    name: "build (NetBSD/amd64 9.3 with pkgsrc)"
+    name: "build-netbsd (NetBSD/amd64 9.3 with pkgsrc)"
     runs-on: ubuntu-latest
 
     steps:
@@ -79,13 +42,35 @@ jobs:
           copyback: false
           # Check https://github.com/NetBSD/pkgsrc/blob/trunk/net/sayaka/Makefile to check dependencies
           prepare: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            pkg_add pkgconf git-base
+            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
+            export PATH
+            pkg_add pkgconf
             pkg_add gcc10
             pkg_add libwebp mbedtls wslay
 
           run: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
+            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
             export PATH=/usr/pkg/gcc10/bin:${PATH}
             CC=/usr/pkg/gcc10/bin/gcc CXX=/usr/pkg/gcc10/bin/g++ sh configure
+            make -DRELEASE sayaka
+
+  build-openbsd:
+    name: "build-openbsd (OpenBSD/amd64 7.4 with pkgsrc)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install packages and run configure and make (on the OpenBSD VM)
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin
+            export PATH
+            pkg_add pkgconf
+            pkg_add libwebp mbedtls wslay
+
+          run: |
+            sh configure
             make -DRELEASE sayaka


### PR DESCRIPTION
https://misskey.io/notes/9q4f7z54drq902sq

> nonoはリリース手順メモにOpenBSDでビルドする、って書いてて、なので毎回必ずビルドしてるけど(毎回まあまあエラー出る)、sayakaちゃんも同じ手順書用意しないとだな。

というのを見たので過去に ibus でごちゃごちゃいじったのを横目で見ながら適当に書いてみました。
NetBSD-vmのバージョンとかgccのバージョンとか、メンテがいろいろめんどくさそうなのであくまでも参考ということで。
https://github.com/vmactions/openbsd-vm を使えば OpenBSDもできるかも。
（パッケージインストールをよくわかっていない）

5行目の
```   branches: [ ci-netbsd ]```
はどのブランチがプッシュされたらactionするか、みたいな感じらしいので
適当に `master` とか入れる必要あるかもしれません。