### PR TITLE
Add a test for FreeBSD.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,3 +120,41 @@ jobs:
             make distclean
             sh configure --enable-twitter
             make -DRELEASE
+
+  build-freesd:
+    name: "build-freebsd (FreeBSD/amd64 14.0 with ports)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install packages and run configure and make (on the FreeBSD VM)
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+            export PATH
+            pkg install -y pkgconf
+            pkg install -y webp mbedtls wslay
+            pkg install -y giflib jpeg-turbo png
+
+          run: |
+            set -e
+            export CPPFLAGS=-DLIBICONV_PLUG
+            echo build with \"configure\"
+            make distclean
+            sh configure
+            make -DRELEASE
+            echo build with \"configure --without-stb-image\"
+            make distclean
+            sh configure --without-stb-image
+            make -DRELEASE
+            echo build with \"configure --without-mbedtls\"
+            make distclean
+            sh configure --without-mbedtls
+            make -DRELEASE
+            echo build with \"configure --enable-twitter\"
+            make distclean
+            sh configure --enable-twitter
+            make -DRELEASE


### PR DESCRIPTION
再びお試しでいろいろ書いてみていて、とりあえず通ったので投げておきます。

FreeBSD で base の libc の `iconv` を使う場合、 ports の `libiconv` と競合しないように
`CPPFLAGS=-DLIBICONV_PLUG` を指定する必要がある
https://cgit.freebsd.org/ports/commit/Mk/Uses/iconv.mk?id=0052e743ef40759774eb918aa5180bcb21ea9cc1
ということのようなのですが、これを `configure` で処置すべきなのか、というのがいまいちわかりませんでした。

一応ビルドは通りますが、 ports の patch を見ると `src/UString.cpp` に `#include <cerrno>` を追加していて、
https://cgit.freebsd.org/ports/tree/net-im/sayaka/files/patch-src_UString.cpp
なんでこれだけ追加しているのだろう、という感じではあります