### PR TITLE
CI: update tests to use NetBSD 10.0 and OpenBSD 7.5.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: install packages
         run: |
+          uname -a
           sudo apt update
           sudo apt upgrade -y
           sudo apt install -y build-essential pkg-config bmake libbsd-dev libwslay-dev libwebp-dev libmbedtls-dev
@@ -45,7 +46,7 @@ jobs:
           bmake -DRELEASE
 
   build-netbsd:
-    name: "build-netbsd (NetBSD/amd64 9.3 with pkgsrc)"
+    name: "build-netbsd (NetBSD/amd64 10.0 with pkgsrc)"
     runs-on: ubuntu-latest
 
     steps:
@@ -53,21 +54,21 @@ jobs:
       - name: Install packages and run configure and make (on the NetBSD VM)
         uses: vmactions/netbsd-vm@v1
         with:
+          release: "10.0"
           usesh: true
           copyback: false
           # Check https://github.com/NetBSD/pkgsrc/blob/trunk/net/sayaka/Makefile to check dependencies
           prepare: |
+            uname -a
             PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
             export PATH
             pkg_add pkgconf
-            pkg_add gcc10
             pkg_add libwebp mbedtls wslay
             pkg_add giflib jpeg png
 
           run: |
             PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            export PATH=/usr/pkg/gcc10/bin:${PATH}
-            export CC=/usr/pkg/gcc10/bin/gcc CXX=/usr/pkg/gcc10/bin/g++
+            export PATH
             echo build with \"configure\"
             make distclean
             sh configure
@@ -86,7 +87,7 @@ jobs:
             make -DRELEASE
 
   build-openbsd:
-    name: "build-openbsd (OpenBSD/amd64 7.4 with ports)"
+    name: "build-openbsd (OpenBSD/amd64 7.5 with ports)"
     runs-on: ubuntu-latest
 
     steps:
@@ -94,9 +95,11 @@ jobs:
       - name: Install packages and run configure and make (on the OpenBSD VM)
         uses: vmactions/openbsd-vm@v1
         with:
+          release: "7.5"
           usesh: true
           copyback: false
           prepare: |
+            uname -a
             PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin
             export PATH
             pkg_add pkgconf
@@ -130,9 +133,11 @@ jobs:
       - name: Install packages and run configure and make (on the FreeBSD VM)
         uses: vmactions/freebsd-vm@v1
         with:
+          release: "14.0"
           usesh: true
           copyback: false
           prepare: |
+            uname -a
             PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
             export PATH
             pkg install -y pkgconf


### PR DESCRIPTION
- NetBSD 10.0 has gcc 10.5.0 so gcc10 package is no longer necessary
- Also explicitly specify release version on each vm
- Print uname before tests

ログのとおりですが、vmactions側が major version 上げずにOSリリースが上がっていくっぽいので明示するようにしました。