### PR TITLE
Make `--ciphers RSA` option work with OpenSSL.

### DIFF
--- a/src/TLSHandle_openssl.cpp
+++ b/src/TLSHandle_openssl.cpp
@@ -76,6 +76,7 @@ TLSHandle_openssl::Init()
 	SSL_load_error_strings();
 	SSL_library_init();
 
+	inner->ctx = SSL_CTX_new(TLS_client_method());
 	return true;
 }
 
@@ -85,7 +86,8 @@ TLSHandle_openssl::UseRSA()
 {
 	int r;
 
-	r = SSL_CTX_set_cipher_list(inner->ctx, "TLS_RSA_WITH_AES_128_CBC_SHA");
+	SSL_CTX_set_options(inner->ctx, SSL_OP_NO_TLSv1_3);
+	r = SSL_CTX_set_cipher_list(inner->ctx, "AES128-SHA256");
 	if (r != 1) {
 		ERR_print_errors_fp(stderr);
 		return false;
@@ -104,7 +106,6 @@ TLSHandle_openssl::Connect(const char *hostname, const char *servname)
 	}
 
 	if (usessl) {
-		inner->ctx = SSL_CTX_new(SSLv23_client_method());
 		inner->ssl = SSL_new(inner->ctx);
 
 		r = SSL_set_fd(inner->ssl, fd);


### PR DESCRIPTION
`configure --without-mbedtls` で OpenSSL仕様でビルドした場合、 `--ciphers RSA` オプション指定で起動すると SIGSEGV します。

ざっと見て、 `inner->ctx = SSL_CTX_new();` を `Connect` で呼ぶのではダメで mbedtls と同様に `Init` で呼ぶ必要があるっぽいので適当に直してみました。
ただ、この場合 `usessl` および `mtls->UseSSL(true)` をどう扱うべきかというのがよくわかっていません。

あと、実動作として RSA で認証させるには以下も必要そうだったので入れてあります。
* `SSL_CTX_set_cipher_list()` では `"AES128-SHA256"` を指定する必要がある
 https://www.openssl.org/docs/man3.0/man1/openssl-ciphers.html#TLS-v1.2-cipher-suites
* TLS 1.3有効だとそもそも RSA は使えないっぽいので TLS 1.2強制のために `SSL_CTX_set_options(inner->ctx, SSL_OP_NO_TLSv1_3)` が必要
* `SSLv23_client_method()` は `TLS_client_method()` のほうがいいような? （これは必須でないかも）
https://www.openssl.org/docs/man3.0/man3/SSLv23_client_method.html#SSLv23_method-SSLv23_server_method-SSLv23_client_method
> These functions do not exist anymore, they have been renamed to TLS_method(), TLS_server_method() and TLS_client_method() respectively.