### PR TITLE
configure: Use pkg-config to check mbedtls.

### DIFF
--- a/configure
+++ b/configure
@@ -4022,6 +4022,45 @@ if test x"${with_mbedtls}" = x"yes"; then
 	#
 	# mbedTLS
 	#
+	# mbedtls 2.28.8 and later has .pc files
+
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for mbedtls" >&5
+printf %s "checking for mbedtls... " >&6; }
+	if ${PKG_CONFIG} --exists mbedtls; then
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+		has_mbedtls=yes
+		H=`${PKG_CONFIG} --cflags mbedtls`
+		L=`${PKG_CONFIG} --libs mbedtls`
+
+		CPPFLAGS="${CPPFLAGS} ${H}"
+		LIBS="${LIBS} ${L}"
+	else
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+		has_mbedtls=no
+	fi
+
+
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for mbedcrypto" >&5
+printf %s "checking for mbedcrypto... " >&6; }
+	if ${PKG_CONFIG} --exists mbedcrypto; then
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+		has_mbedcrypto=yes
+		H=`${PKG_CONFIG} --cflags mbedcrypto`
+		L=`${PKG_CONFIG} --libs mbedcrypto`
+
+		CPPFLAGS="${CPPFLAGS} ${H}"
+		LIBS="${LIBS} ${L}"
+	else
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+		has_mbedcrypto=no
+	fi
+
+	if test "x${has_mbedtls}" \!= x"yes"; then
+		# older mbedtls might not have pkgconf so check these manually
 
 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for mbedtls" >&5
 printf %s "checking for mbedtls... " >&6; }
@@ -4040,17 +4079,17 @@ printf %s "checking for mbedtls... " >&6; }
 		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-	#include <mbedtls/net_sockets.h>
-		#include <mbedtls/entropy.h>
+			#include <mbedtls/net_sockets.h>
+			#include <mbedtls/entropy.h>
 
 int
 main (void)
 {
 
-		mbedtls_net_context net;
-		mbedtls_entropy_context e;
-		mbedtls_net_init(&net);
-		mbedtls_entropy_init(&e);
+			mbedtls_net_context net;
+			mbedtls_entropy_context e;
+			mbedtls_net_init(&net);
+			mbedtls_entropy_init(&e);
 
   ;
   return 0;
@@ -4081,6 +4120,7 @@ printf "%s\n" "yes" >&6; }
 printf "%s\n" "no" >&6; }
 	fi
 
+	fi
 	if test "x${has_mbedtls}" = "xyes"; then
 		printf "%s\n" "#define USE_MBEDTLS 1" >>confdefs.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -281,15 +281,21 @@ if test x"${with_mbedtls}" = x"yes"; then
 	#
 	# mbedTLS
 	#
-	CHECK_LIB([mbedtls], [-lmbedtls -lmbedcrypto], [
-	#include <mbedtls/net_sockets.h>
-		#include <mbedtls/entropy.h>
-	], [
-		mbedtls_net_context net;
-		mbedtls_entropy_context e;
-		mbedtls_net_init(&net);
-		mbedtls_entropy_init(&e);
-	])
+	# mbedtls 2.28.8 and later has .pc files
+	CHECK_PKG([mbedtls])
+	CHECK_PKG([mbedcrypto])
+	if test "x${has_mbedtls}" \!= x"yes"; then
+		# older mbedtls might not have pkgconf so check these manually
+		CHECK_LIB([mbedtls], [-lmbedtls -lmbedcrypto], [
+			#include <mbedtls/net_sockets.h>
+			#include <mbedtls/entropy.h>
+		], [
+			mbedtls_net_context net;
+			mbedtls_entropy_context e;
+			mbedtls_net_init(&net);
+			mbedtls_entropy_init(&e);
+		])
+	fi
 	if test "x${has_mbedtls}" = "xyes"; then
 		AC_DEFINE([USE_MBEDTLS])
 		AC_SUBST([MAKE_MBEDTLS], [yes])


### PR DESCRIPTION
mbedtls-2.28.8 and later have pkgconf files, but also check them manually as before for older versions.

---

* pkgsrc/security/mbedtls は 2.28.3 → 2.28.8 に上げたので pkgsrc-2024Q3 では新しくなると思います
https://mail-index.netbsd.org/pkgsrc-changes/2024/08/15/msg305566.html
	* FreeBSD ports, ubuntu 24.04 も 2.28.8 になっているようです。 ubuntu 22.04 は 2.28.0 ですが
* CI をいろいろ試していたら archLinux だと mbedtls2 と mbedtls (3.x) 共存のために mbedtls2 が `/usr/include/mbedtls2` とか `/usr/lib/mbdedtls2` とかに入るので `pkg-config` 使えるならちょっと楽です
	* ただし `.pc` ファイルも `/usr/pkg/lib/mbedtls2/pkgconfig` にあるので `PKG_CONFIG_PATH` 指定は必要
* 2.28.7 以前のために従来のチェックは残す
	* `checking for mbedtls...` が2回表示されますが、 `csrc/configure` の curl でも同様っぽいので気にしないでよい?

* `CHECK_PKG([mbedcrypto])` は `has_mbedtls = yes` 側に入れてもいいかもしれませんがあまりこだわってません
	* 今見たら同様の `-lwebpdemux` は手動で足されてますが、こちらも `CHECK_PKG([libwebpdemux])` にしてもよいのかも……